### PR TITLE
#847 -  Change default of multi-panel to left.

### DIFF
--- a/config/content/multi_panel.json
+++ b/config/content/multi_panel.json
@@ -96,7 +96,7 @@
           "id": "text_align",
           "label": "Text alignment",
           "type": "select",
-          "default": "center",
+          "default": "left",
           "options": [
             {
               "value": "left",


### PR DESCRIPTION
Changed the default text alignment of multi-panel to 'left' (from 'center'), to fit current design consistency.