### PR TITLE
#779 – Add default link text to generated links.

### DIFF
--- a/config/content/full_width_media.json
+++ b/config/content/full_width_media.json
@@ -49,6 +49,7 @@
               "id": "label",
               "label": "Label text",
               "type": "text",
+              "default": "Click me",
               "required": true
             },
             {


### PR DESCRIPTION
Fixes https://gitlab.com/schema/swell-admin/-/issues/779.  