### PR TITLE
#926 - Accom. rel./absol. URLs for FWM and MP.

### DIFF
--- a/components/BaseLink.vue
+++ b/components/BaseLink.vue
@@ -1,0 +1,39 @@
+<template>
+  <component
+    v-bind="linkProps(resolveUrl(link))"
+    :is="null"
+    :title="link.title"
+    :class="[link.cssClasses]"
+    aria-current="page"
+  >
+    {{ link.label }}
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'BaseLink',
+  props: {
+    link: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    linkProps(path) {
+      if (path.match(/^(http(s)?|ftp):\/\//) || path.target === '_blank') {
+        return {
+          is: 'a',
+          href: path,
+          target: '_blank',
+          rel: 'noopener'
+        }
+      }
+      return {
+        is: 'nuxt-link',
+        to: path
+      }
+    }
+  }
+}
+</script>

--- a/components/SectionFullWidthMedia.vue
+++ b/components/SectionFullWidthMedia.vue
@@ -62,7 +62,7 @@
           >
             {{ heading }}
           </h2>
-          <!-- Tell prettier not to add extra whitespace -->
+          <!-- Tell prettier n\ot to add extra whitespace -->
           <!-- display: inline -->
           <p
             v-balance-text.children
@@ -72,35 +72,16 @@
           >
           </p>
           <div :class="{ '-ml-3': alignX !== 'center' }">
-            <template v-for="(link, index) in links">
-              <!-- Relative Links -->
-              <NuxtLink
-                v-if="!isAbsoluteURL(link.url)"
-                :key="id + 'link' + index"
-                :to="resolveUrl(link)"
-                :title="link.title"
-                :class="{
-                  'cta-link mt-5 mb-1 mx-3': link.style === 'text',
-                  'btn mt-6 mx-3': link.style === 'button_primary',
-                  light: textColor === 'light'
-                }"
-                >{{ link.label || '&nbsp;' }}</NuxtLink
-              >
-
-              <!-- Absolute Links -->
-              <a
-                v-else
-                :key="id + 'link' + index"
-                :href="link.url"
-                :title="link.title"
-                :class="{
-                  'cta-link mt-5 mb-1 mx-3': link.style === 'text',
-                  'btn mt-6 mx-3': link.style === 'button_primary',
-                  light: textColor === 'light'
-                }"
-                >{{ link.label || '&nbsp;' }}</a
-              >
-            </template>
+            <BaseLink
+              v-for="(link, index) in links"
+              :link="link"
+              :key="id + 'link' + index"
+              :class="{
+                'cta-link mt-5 mb-1 mx-3': link.style === 'text',
+                'btn mt-6 mx-3': link.style === 'button_primary',
+                light: textColor === 'light'
+              }"
+            />
           </div>
         </div>
         <!-- END Text content -->

--- a/components/SectionFullWidthMedia.vue
+++ b/components/SectionFullWidthMedia.vue
@@ -72,18 +72,35 @@
           >
           </p>
           <div :class="{ '-ml-3': alignX !== 'center' }">
-            <NuxtLink
-              v-for="(link, index) in links"
-              :key="id + 'link' + index"
-              :to="resolveUrl(link)"
-              :title="link.title"
-              :class="{
-                'cta-link mt-5 mb-1 mx-3': link.style === 'text',
-                'btn mt-6 mx-3': link.style === 'button_primary',
-                light: textColor === 'light'
-              }"
-              >{{ link.label || '&nbsp;' }}</NuxtLink
-            >
+            <template v-for="(link, index) in links">
+              <!-- Relative Links -->
+              <NuxtLink
+                v-if="!isAbsoluteURL(link.url)"
+                :key="id + 'link' + index"
+                :to="resolveUrl(link)"
+                :title="link.title"
+                :class="{
+                  'cta-link mt-5 mb-1 mx-3': link.style === 'text',
+                  'btn mt-6 mx-3': link.style === 'button_primary',
+                  light: textColor === 'light'
+                }"
+                >{{ link.label || '&nbsp;' }}</NuxtLink
+              >
+
+              <!-- Absolute Links -->
+              <a
+                v-else
+                :key="id + 'link' + index"
+                :href="link.url"
+                :title="link.title"
+                :class="{
+                  'cta-link mt-5 mb-1 mx-3': link.style === 'text',
+                  'btn mt-6 mx-3': link.style === 'button_primary',
+                  light: textColor === 'light'
+                }"
+                >{{ link.label || '&nbsp;' }}</a
+              >
+            </template>
           </div>
         </div>
         <!-- END Text content -->

--- a/components/SectionMultiPanel.vue
+++ b/components/SectionMultiPanel.vue
@@ -50,11 +50,15 @@
             :class="{ 'inline-block': panel.links.length < 3 }"
           >
             <NuxtLink
-              v-if="link"
+              v-if="!isAbsoluteURL(link.url)"
               :to="resolveUrl(link)"
               class="cta-link mt-4 mb-1 mx-3 inline-block"
               >{{ link.label }}</NuxtLink
             >
+
+            <a v-else :href="link.url" class="cta-link mt-4 mb-1 mx-3 inline-block">{{
+              link.label
+            }}</a>
           </div>
         </div>
       </template>

--- a/components/SectionMultiPanel.vue
+++ b/components/SectionMultiPanel.vue
@@ -49,16 +49,7 @@
             class="m-1 mx-2"
             :class="{ 'inline-block': panel.links.length < 3 }"
           >
-            <NuxtLink
-              v-if="!isAbsoluteURL(link.url)"
-              :to="resolveUrl(link)"
-              class="cta-link mt-4 mb-1 mx-3 inline-block"
-              >{{ link.label }}</NuxtLink
-            >
-
-            <a v-else :href="link.url" class="cta-link mt-4 mb-1 mx-3 inline-block">{{
-              link.label
-            }}</a>
+            <BaseLink :link="link" class="cta-link mt-4 mb-1 mx-3 inline-block" />
           </div>
         </div>
       </template>

--- a/modules/swell/mixin.js
+++ b/modules/swell/mixin.js
@@ -9,8 +9,7 @@ Vue.use({
     Vue.mixin({
       methods: {
         formatMoney,
-        resolveUrl,
-        isAbsoluteURL
+        resolveUrl
       }
     })
 
@@ -79,11 +78,6 @@ function resolveUrl(item) {
 
     return itemPath // TODO wrap nuxt-i18n to generate localized path
   }
-}
-
-function isAbsoluteURL(url) {
-  const absoluteURLPattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi
-  return absoluteURLPattern.test(url)
 }
 
 function getContentPath({ type, value, url }) {

--- a/modules/swell/mixin.js
+++ b/modules/swell/mixin.js
@@ -9,7 +9,8 @@ Vue.use({
     Vue.mixin({
       methods: {
         formatMoney,
-        resolveUrl
+        resolveUrl,
+        isAbsoluteURL
       }
     })
 
@@ -64,7 +65,7 @@ function resolveUrl(item) {
     // Build full path from link item object
     let itemPath = getContentPath(item)
 
-    // Add/remove trailing slash according to router configuration
+    // Add/remove trailing slash  according to router configuration
     const useTrailingSlash = '<%= options.trailingSlash %>' === 'true'
     const endsWithSlash = itemPath.slice(-1) === '/'
 
@@ -77,13 +78,18 @@ function resolveUrl(item) {
     }
 
     return itemPath // TODO wrap nuxt-i18n to generate localized path
-  } else {
-    // Treat item as complete URL
-    return item
   }
 }
 
-function getContentPath({ type, value }) {
+function isAbsoluteURL(url) {
+  const absoluteURLPattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi
+  return absoluteURLPattern.test(url)
+}
+
+function getContentPath({ type, value, url }) {
+  // Return URL value for linked links
+  if (typeof type === 'undefined' && url) return url
+
   // Return URL value as-is
   if (type === 'url') return value
 


### PR DESCRIPTION
Fixes https://gitlab.com/schema/swell-admin/-/issues/960. 

- Tweaked `resolveUrl` to work with component link schema.
- Accomodated for relative/absolute links in `FullWidthMedia` and `MultiPanel` components and rendering them as `NuxtLink` or `a hrefs` respectively.