### PR TITLE
fix: Change URL field to collection field.

### DIFF
--- a/components/SectionLargeMedia.vue
+++ b/components/SectionLargeMedia.vue
@@ -13,7 +13,7 @@
         {{ description }}
       </p>
       <div v-if="image" class="relative xl:mx-12">
-        <BaseLink v-if="url" :link="url">
+        <BaseLink v-if="link && link.length" :link="link[0]">
           <VisualMedia
             :source="image"
             aspect-ratio="16:9"
@@ -55,9 +55,9 @@ export default {
       type: String,
       default: 'primary-lighter'
     },
-    url: {
-      type: String,
-      default: null
+    link: {
+      type: [Object, Array],
+      default: () => ({})
     }
   }
 }

--- a/components/SectionMultiPanel.vue
+++ b/components/SectionMultiPanel.vue
@@ -31,7 +31,7 @@
       </div>
       <!-- Image panel -->
       <template v-else-if="panel.type === 'image'">
-        <BaseLink v-if="panel.url" :link="panel.url">
+        <BaseLink v-if="panel.link && panel.link.length" :link="panel.link[0]">
           <VisualMedia
             :source="panel.image"
             :is-background="true"

--- a/config/content/large_media.json
+++ b/config/content/large_media.json
@@ -23,9 +23,17 @@
           "required": true
         },
         {
-          "id": "url",
-          "label": "Image URL",
-          "type": "url"
+          "id": "link",
+          "label": "Image Link",
+          "type": "collection",
+          "max": 1,
+          "fields": [
+            {
+              "id": "url",
+              "label": "Link URL",
+              "type": "url"
+            }
+          ]
         }
       ]
     },

--- a/config/content/multi_panel.json
+++ b/config/content/multi_panel.json
@@ -93,9 +93,17 @@
                   "required": true
                 },
                 {
-                  "id": "url",
-                  "label": "Image URL",
-                  "type": "url"
+                  "id": "link",
+                  "label": "Image Link",
+                  "type": "collection",
+                  "max": 1,
+                  "fields": [
+                    {
+                      "id": "url",
+                      "label": "Link URL",
+                      "type": "url"
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
See [issue](https://linear.app/swell/issue/SW-17/large-media-url-every-time-i-set-up-a-link-and-click-it-it-sends-me-to.). In the meantime, change URL fields to collection of links.