### PR TITLE
fix: Add condit. for darken style + text color fix

### DIFF
--- a/config/content/category.json
+++ b/config/content/category.json
@@ -35,7 +35,7 @@
       "default": 20,
       "min": 0,
       "max": 50,
-      "conditions": { "text_color": "light" }
+      "conditions": { "text_color": "light", "show_hero_image": true }
     },
     {
       "id": "product_cols",

--- a/pages/categories/_slug.vue
+++ b/pages/categories/_slug.vue
@@ -25,9 +25,20 @@
         class="absolute w-full h-full inset-0 bg-primary-darkest"
       ></div>
       <div v-if="category" class="container absolute text-center center-xy">
-        <h1 class="text-primary-lightest">{{ category.name }}</h1>
+        <h1
+          :class="{
+            'text-primary-lightest': settings.textColor === 'light',
+            'text-primary-darkest': settings.textColor === 'dark'
+          }"
+        >
+          {{ category.name }}
+        </h1>
         <div
-          class="mx-auto text-lg text-primary-lightest max-w-128"
+          class="mx-auto text-lg max-w-128"
+          :class="{
+            'text-primary-lightest': settings.textColor === 'light',
+            'text-primary-darkest': settings.textColor === 'dark'
+          }"
           v-html="category.description"
         ></div>
       </div>


### PR DESCRIPTION
Tweak field condition of darken background style of Category header images, to only show when `text_color` is `light` and `show_hero_image` is true. Have also made sure that `text_color`:`dark` is applied to the text if selected.