### PR TITLE
Merge Swell-generated and user-supplied routes

### DIFF
--- a/modules/swell/index.js
+++ b/modules/swell/index.js
@@ -71,7 +71,14 @@ export default async function (moduleOptions) {
     return extendPluginsFn ? extendPluginsFn(plugins) : plugins;
   };
 
-  this.options.generate.routes = () => getRoutes(swell);
+  // add Swell routes to existing routes
+  const nuxtRoutes = this.options.generate.routes;
+  if (typeof nuxtRoutes === 'function') {
+    this.options.generate.routes = async () => (await nuxtRoutes()).concat(await getRoutes(swell));
+  }
+  if (Array.isArray(nuxtRoutes)) {
+    this.options.generate.routes = async () => nuxtRoutes.concat(await getRoutes(swell));
+  }
 
   this.nuxt.hook('generate:done', (context) => {
     const { locales } = context.options.i18n;


### PR DESCRIPTION
Currently there's no way for the end-user to supply their own routes to be generated, as is the case when implementing e.g. a blog section.

This PR updates the Swell plugin so that it merges the Swell-generated routes with the routes already supplied by the user in  nuxt.config.js.