### PR TITLE
Fixed slugs in orders and subscription page

### DIFF
--- a/components/AccountPauseResumeSubscriptionPopup.vue
+++ b/components/AccountPauseResumeSubscriptionPopup.vue
@@ -17,8 +17,8 @@
             <h3>
               {{
                 paused
-                  ? $t('account.subscriptions.id.popup.resume.title')
-                  : $t('account.subscriptions.id.popup.pause.title')
+                  ? $t('account.subscriptions._id.popup.resume.title')
+                  : $t('account.subscriptions._id.popup.pause.title')
               }}
             </h3>
             <button class="ml-auto" @click.prevent="$emit('click-close')">
@@ -28,8 +28,8 @@
           <p class="pb-6">
             {{
               paused
-                ? $t('account.subscriptions.id.popup.resume.message')
-                : $t('account.subscriptions.id.popup.pause.message')
+                ? $t('account.subscriptions._id.popup.resume.message')
+                : $t('account.subscriptions._id.popup.pause.message')
             }}
           </p>
 
@@ -54,8 +54,8 @@
                 ></span>
                 {{
                   paused
-                    ? $t('account.subscriptions.id.popup.resume.resumeNow')
-                    : $t('account.subscriptions.id.popup.pause.pauseNow')
+                    ? $t('account.subscriptions._id.popup.resume.resumeNow')
+                    : $t('account.subscriptions._id.popup.pause.pauseNow')
                 }}</label
               >
             </div>
@@ -80,8 +80,8 @@
                 ></span>
                 {{
                   paused
-                    ? $t('account.subscriptions.id.popup.resume.chooseDate')
-                    : $t('account.subscriptions.id.popup.pause.skipCycle')
+                    ? $t('account.subscriptions._id.popup.resume.chooseDate')
+                    : $t('account.subscriptions._id.popup.pause.skipCycle')
                 }}
               </label>
             </div>
@@ -95,8 +95,8 @@
               :label="confirmButtonLabel"
               :loading-label="
                 paused
-                  ? $t('account.subscriptions.id.popup.resume.loading')
-                  : $t('account.subscriptions.id.popup.pause.loading')
+                  ? $t('account.subscriptions._id.popup.resume.loading')
+                  : $t('account.subscriptions._id.popup.pause.loading')
               "
               :is-loading="isLoading"
               @click.native="accept()"
@@ -107,8 +107,8 @@
               appearance="light"
               :label="
                 paused
-                  ? $t('account.subscriptions.id.popup.resume.no')
-                  : $t('account.subscriptions.id.popup.pause.no')
+                  ? $t('account.subscriptions._id.popup.resume.no')
+                  : $t('account.subscriptions._id.popup.pause.no')
               "
               @click.native="$emit('click-close')"
             />
@@ -150,10 +150,10 @@ export default {
 
     confirmButtonLabel() {
       return this.paused && this.interval === 'set'
-        ? this.$t('account.subscriptions.id.popup.resume.continue')
+        ? this.$t('account.subscriptions._id.popup.resume.continue')
         : this.paused
-        ? this.$t('account.subscriptions.id.popup.resume.yes')
-        : this.$t('account.subscriptions.id.popup.pause.yes');
+        ? this.$t('account.subscriptions._id.popup.resume.yes')
+        : this.$t('account.subscriptions._id.popup.pause.yes');
     },
   },
 

--- a/components/AccountSubscriptionDateTimePopup.vue
+++ b/components/AccountSubscriptionDateTimePopup.vue
@@ -13,15 +13,15 @@
       >
         <div class="container h-full">
           <h3 class="pb-2">
-            {{ $t('account.subscriptions.id.popup.chooseDate.title') }}
+            {{ $t('account.subscriptions._id.popup.chooseDate.title') }}
           </h3>
           <p class="pb-6">
-            {{ $t('account.subscriptions.id.popup.chooseDate.message') }}
+            {{ $t('account.subscriptions._id.popup.chooseDate.message') }}
           </p>
 
           <!-- Options -->
           <label class="label-xs-bold-faded mb-2 block">{{
-            $t('account.subscriptions.id.popup.chooseDate.date.label')
+            $t('account.subscriptions._id.popup.chooseDate.date.label')
           }}</label>
           <div class="mb-6">
             <div class="relative mb-2">
@@ -41,7 +41,7 @@
                 v-if="!$v.date.required"
                 class="label-sm mt-2 text-error-default"
                 >{{
-                  $t('account.subscriptions.id.popup.chooseDate.date.required')
+                  $t('account.subscriptions._id.popup.chooseDate.date.required')
                 }}</span
               >
 
@@ -49,14 +49,14 @@
                 v-else-if="!$v.date.validDate"
                 class="label-sm mt-2 text-error-default"
                 >{{
-                  $t('account.subscriptions.id.popup.chooseDate.date.valid')
+                  $t('account.subscriptions._id.popup.chooseDate.date.valid')
                 }}</span
               >
             </template>
           </div>
 
           <label class="label-xs-bold-faded mb-2 block">{{
-            $t('account.subscriptions.id.popup.chooseDate.time.label')
+            $t('account.subscriptions._id.popup.chooseDate.time.label')
           }}</label>
           <div class="mb-6">
             <div class="relative mb-2">
@@ -75,7 +75,7 @@
                 v-if="!$v.time.required"
                 class="label-sm mt-2 text-error-default"
                 >{{
-                  $t('account.subscriptions.id.popup.chooseDate.time.required')
+                  $t('account.subscriptions._id.popup.chooseDate.time.required')
                 }}</span
               >
 
@@ -83,7 +83,7 @@
                 v-else-if="!$v.time.validDateTime"
                 class="label-sm mt-2 text-error-default"
                 >{{
-                  $t('account.subscriptions.id.popup.chooseDate.time.valid')
+                  $t('account.subscriptions._id.popup.chooseDate.time.valid')
                 }}</span
               >
             </template>
@@ -103,9 +103,9 @@
           <BaseButton
             class="mt-4"
             appearance="dark"
-            :label="$t('account.subscriptions.id.popup.chooseDate.yes')"
+            :label="$t('account.subscriptions._id.popup.chooseDate.yes')"
             :loading-label="
-              $t('account.subscriptions.id.popup.chooseDate.loading')
+              $t('account.subscriptions._id.popup.chooseDate.loading')
             "
             :is-loading="isLoading"
             @click.native="resumeOnDate"
@@ -114,7 +114,7 @@
           <BaseButton
             class="mt-4"
             appearance="light"
-            :label="$t('account.subscriptions.id.popup.chooseDate.no')"
+            :label="$t('account.subscriptions._id.popup.chooseDate.no')"
             @click.native="$emit('click-close')"
           />
         </div>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "scripts": {
     "dev": "nuxt",
     "watch": "nuxt",
-    "build": "yarn sync && nuxt build",
+    "build": "yarn sync && nuxt build && nuxt generate",
     "generate": "yarn sync && nuxt generate",
     "start": "nuxt start",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=16.20.0",
+    "node": "16.20",
     "npm": ">=8.19.4"
   },
   "dependencies": {

--- a/pages/account/orders/_id.vue
+++ b/pages/account/orders/_id.vue
@@ -7,7 +7,7 @@
         class="mb-6 flex cursor-pointer items-center"
       >
         <BaseIcon icon="uil:angle-left" size="sm" /><span class="ml-1">{{
-          $t('account.orders.id.backToOrders')
+          $t('account.orders._id.backToOrders')
         }}</span>
       </NuxtLink>
     </div>
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="mb-10 border-b border-primary-med pb-6">
           <h2 class="text-2xl">
-            {{ $t('account.orders.id.order') }} #{{ order.number }}
+            {{ $t('account.orders._id.order') }} #{{ order.number }}
           </h2>
 
           <div class="my-4">
@@ -48,7 +48,7 @@
             class="mb-6 block rounded border border-primary-med p-4 text-sm md:flex md:justify-between"
           >
             <div class="pb-2 md:pb-0">
-              <span>{{ $t('account.orders.id.orderDate') }}</span>
+              <span>{{ $t('account.orders._id.orderDate') }}</span>
               <span class="font-semibold">{{
                 formatDate(order.dateCreated)
               }}</span>
@@ -60,7 +60,7 @@
             </div> -->
 
             <div>
-              <span>{{ $t('account.orders.id.total') }}</span>
+              <span>{{ $t('account.orders._id.total') }}</span>
               <span class="font-semibold">{{
                 formatMoneyRounded(order.grandTotal, order.currency)
               }}</span>
@@ -71,7 +71,7 @@
             v-if="order.status === 'complete'"
             fit="auto"
             appearance="light"
-            :label="$t('account.orders.id.createReturn')"
+            :label="$t('account.orders._id.createReturn')"
             :link="{
               url: localePath('/account/orders/returns/'),
               title: 'Create return',
@@ -80,9 +80,9 @@
 
           <!-- Order summary -->
           <div class="flex border-b border-primary-med py-6 font-semibold">
-            <span>{{ $t('account.orders.id.orderSummary') }}</span>
+            <span>{{ $t('account.orders._id.orderSummary') }}</span>
             <span class="ml-auto">{{
-              $tc('account.orders.id.items', order.items.length, {
+              $tc('account.orders._id.items', order.items.length, {
                 count: order.items.length,
               })
             }}</span>
@@ -120,7 +120,7 @@
                 <div class="text-sm">
                   <p v-if="item.quantity > 1">
                     {{
-                      $tc('account.orders.id.quantity', item.quantity, {
+                      $tc('account.orders._id.quantity', item.quantity, {
                         count: item.quantity,
                       })
                     }}
@@ -134,7 +134,7 @@
                     class="pt-2"
                   >
                     <p class="font-semibold">
-                      {{ $t('account.orders.id.bundleIncludes') }}
+                      {{ $t('account.orders._id.bundleIncludes') }}
                     </p>
                     <div
                       v-for="bundleItem in item.bundleItems"
@@ -165,14 +165,14 @@
           </div>
 
           <div class="flex pb-2">
-            <span>{{ $t('account.orders.id.subtotal') }}</span>
+            <span>{{ $t('account.orders._id.subtotal') }}</span>
             <span class="ml-auto">{{
               formatMoney(order.subTotal, order.currency)
             }}</span>
           </div>
 
           <div v-if="order.shipmentDelivery" class="flex pb-2">
-            <span>{{ $t('account.orders.id.shipping') }}</span>
+            <span>{{ $t('account.orders._id.shipping') }}</span>
             <span class="ml-auto">{{
               order.shipmentPrice === 0
                 ? 'Free'
@@ -181,21 +181,21 @@
           </div>
 
           <div v-if="order.itemDiscount > 0" class="flex pb-2">
-            <span>{{ $t('account.orders.id.discountsAndCredits') }}</span>
+            <span>{{ $t('account.orders._id.discountsAndCredits') }}</span>
             <span class="ml-auto"
               >-{{ formatMoney(order.itemDiscount, order.currency) }}</span
             >
           </div>
 
           <div v-if="order.taxTotal > 0" class="flex pb-2">
-            <span>{{ $t('account.orders.id.taxes') }}</span>
+            <span>{{ $t('account.orders._id.taxes') }}</span>
             <span class="ml-auto">{{
               formatMoney(order.taxTotal, order.currency)
             }}</span>
           </div>
 
           <div class="flex text-lg font-semibold">
-            <span>{{ $t('account.orders.id.total') }}</span>
+            <span>{{ $t('account.orders._id.total') }}</span>
             <span class="ml-auto">{{
               formatMoneyRounded(order.grandTotal, order.currency)
             }}</span>
@@ -207,13 +207,13 @@
       <div class="container">
         <template v-if="order.shipmentDelivery">
           <p class="pb-4 text-base font-semibold">
-            {{ $t('account.orders.id.deliveryDetails') }}
+            {{ $t('account.orders._id.deliveryDetails') }}
           </p>
 
           <div class="mb-10">
             <div class="rounded border border-primary-med p-4 text-sm">
               <p class="pb-2 font-semibold">
-                {{ $t('account.orders.id.deliveryAddress') }}
+                {{ $t('account.orders._id.deliveryAddress') }}
               </p>
               <p>
                 {{ shipping.name }}<br />
@@ -227,7 +227,7 @@
               class="-mt-px rounded border border-primary-med p-4 text-sm"
             >
               <p class="pb-2 font-semibold">
-                {{ $t('account.orders.id.phoneNumber') }}
+                {{ $t('account.orders._id.phoneNumber') }}
               </p>
               <p>
                 {{ shipping.phone }}
@@ -235,7 +235,7 @@
             </div>
             <div class="-mt-px rounded border border-primary-med p-4 text-sm">
               <p class="pb-2 font-semibold">
-                {{ $t('account.orders.id.deliveryMethod') }}
+                {{ $t('account.orders._id.deliveryMethod') }}
               </p>
               <p v-if="shipping.serviceName">
                 {{ shipping.serviceName }}
@@ -249,7 +249,7 @@
               class="-mt-px rounded border border-primary-med p-4 text-sm"
             >
               <p class="pb-2 font-semibold">
-                {{ $t('account.orders.id.fulfilledDeliveries') }}
+                {{ $t('account.orders._id.fulfilledDeliveries') }}
               </p>
               <div
                 v-for="shipment in shipments"
@@ -258,7 +258,7 @@
               >
                 <div class="grid grid-cols-2-max">
                   <strong class="pr-4 capitalize">{{
-                    $tc('account.orders.id.items', shipment.items.length)
+                    $tc('account.orders._id.items', shipment.items.length)
                   }}</strong>
                   <div>
                     <p v-for="item in shipment.items" :key="item.id">
@@ -269,21 +269,21 @@
 
                   <template v-if="shipment.carrierName">
                     <strong class="pr-4">{{
-                      $t('account.orders.id.carrier')
+                      $t('account.orders._id.carrier')
                     }}</strong>
                     <div>{{ shipment.carrierName }}</div>
                   </template>
 
                   <template v-if="shipment.trackingCode">
                     <strong class="pr-4">{{
-                      $t('account.orders.id.trackingCode')
+                      $t('account.orders._id.trackingCode')
                     }}</strong>
                     <div>{{ shipment.trackingCode }}</div>
                   </template>
 
                   <template v-if="shipment.dateCreated">
                     <strong class="pr-4">{{
-                      $t('account.orders.id.dateShipped')
+                      $t('account.orders._id.dateShipped')
                     }}</strong>
                     <div>{{ formatDate(shipment.dateCreated) }}</div>
                   </template>
@@ -296,7 +296,7 @@
           <template v-if="order.paid">
             <div class="mb-10">
               <p class="pb-4 text-base font-semibold">
-                {{ $t('account.orders.id.paymentMethod') }}
+                {{ $t('account.orders._id.paymentMethod') }}
               </p>
 
               <div
@@ -336,10 +336,10 @@
                     <BaseIcon icon="uil:money-bill" />
                     <span
                       class="ml-auto text-sm font-semibold md:ml-0 md:pl-4"
-                      >{{ $t('account.orders.id.accountCredit') }}</span
+                      >{{ $t('account.orders._id.accountCredit') }}</span
                     >
                   </div>
-                  <p>{{ $t('account.orders.id.accountCreditMessage') }}</p>
+                  <p>{{ $t('account.orders._id.accountCreditMessage') }}</p>
                 </div>
 
                 <!-- Method: Gift Card -->
@@ -351,7 +351,7 @@
                     <BaseIcon icon="uil:gift" />
                     <span
                       class="ml-auto text-sm font-semibold md:ml-0 md:pl-4"
-                      >{{ $t('account.orders.id.giftCard') }}</span
+                      >{{ $t('account.orders._id.giftCard') }}</span
                     >
                   </div>
 
@@ -363,7 +363,7 @@
 
                   <p class="pt-4 text-sm">
                     <span class="pr-2 font-semibold">{{
-                      $t('account.orders.id.total')
+                      $t('account.orders._id.total')
                     }}</span
                     ><span>{{
                       formatMoney(order.giftcardTotal, order.currency)
@@ -380,10 +380,10 @@
                     <BaseIcon icon="uil:University" />
                     <span
                       class="ml-auto text-sm font-semibold md:ml-0 md:pl-4"
-                      >{{ $t('account.orders.id.bankDeposit') }}</span
+                      >{{ $t('account.orders._id.bankDeposit') }}</span
                     >
                   </div>
-                  <p>{{ $t('account.orders.id.bankDepositMessage') }}</p>
+                  <p>{{ $t('account.orders._id.bankDepositMessage') }}</p>
                 </div>
 
                 <!-- Method: Cash on delivery -->
@@ -395,15 +395,15 @@
                     <BaseIcon icon="uil:money-bill" />
                     <span
                       class="ml-auto text-sm font-semibold md:ml-0 md:pl-4"
-                      >{{ $t('account.orders.id.cashOnDelivery') }}</span
+                      >{{ $t('account.orders._id.cashOnDelivery') }}</span
                     >
                   </div>
-                  <p>{{ $t('account.orders.id.cashOnDeliveryMessage') }}</p>
+                  <p>{{ $t('account.orders._id.cashOnDeliveryMessage') }}</p>
                 </div>
 
                 <div class="p-4 text-sm">
                   <p class="pb-2 font-semibold">
-                    {{ $t('account.orders.id.billingAddress') }}
+                    {{ $t('account.orders._id.billingAddress') }}
                   </p>
                   <p>
                     {{ billing.name }}<br />

--- a/pages/account/subscriptions/_id/edit.vue
+++ b/pages/account/subscriptions/_id/edit.vue
@@ -15,14 +15,14 @@
           class="mb-6 flex cursor-pointer items-center"
         >
           <BaseIcon icon="uil:angle-left" size="sm" /><span class="ml-1">
-            {{ $t('account.subscriptions.id.edit.backToSubscription') }}
+            {{ $t('account.subscriptions._id.edit.backToSubscription') }}
             {{ subscriptionName }}
           </span>
         </NuxtLink>
 
         <div class="mb-6">
           <h2 class="mb-2 text-2xl">
-            {{ $t('account.subscriptions.id.edit.title') }}
+            {{ $t('account.subscriptions._id.edit.title') }}
           </h2>
 
           <div class="mb-6">
@@ -58,7 +58,7 @@
           :href="'mailto:' + supportEmail"
           class="btn light mb-6 md:w-auto"
         >
-          {{ $t('account.subscriptions.id.edit.contact') }}
+          {{ $t('account.subscriptions._id.edit.contact') }}
         </a>
 
         <!-- Edit frequency of plan -->
@@ -67,13 +67,13 @@
           class="mb-6"
           fit="auto"
           appearance="light"
-          :label="$t('account.subscriptions.id.edit.changeFrequency')"
+          :label="$t('account.subscriptions._id.edit.changeFrequency')"
           @click.native="changeFrequencyPopupisActive = true"
         />
 
         <!-- Plan items -->
         <span class="label-xs-bold-faded block">{{
-          $t('account.subscriptions.id.edit.plan')
+          $t('account.subscriptions._id.edit.plan')
         }}</span>
 
         <div class="mb-6 border-b border-primary-light">
@@ -86,7 +86,7 @@
               <h4 class="pb-2">{{ subscription.product.name }}</h4>
               <p v-if="subscription.quantity > 1">
                 {{
-                  $tc('account.orders.id.quantity', subscription.quantity, {
+                  $tc('account.orders._id.quantity', subscription.quantity, {
                     count: subscription.quantity,
                   })
                 }}
@@ -113,7 +113,7 @@
             class="mb-6 block"
             fit="auto"
             appearance="light"
-            :label="$t('account.subscriptions.id.edit.changeOptions')"
+            :label="$t('account.subscriptions._id.edit.changeOptions')"
             @click.native="changeOptionsPopupisActive = true"
           />
         </div>
@@ -124,7 +124,7 @@
           class="mb-6 block"
           fit="auto"
           appearance="light-error"
-          :label="$t('account.subscriptions.id.cancelSubscription')"
+          :label="$t('account.subscriptions._id.cancelSubscription')"
           @click.native="cancelPopupIsActive = true"
         />
       </div>
@@ -133,17 +133,17 @@
       <AccountEditFrequencyPopup
         v-if="changeFrequencyPopupisActive"
         :heading="
-          $t('account.subscriptions.id.edit.popup.changeFrequency.title')
+          $t('account.subscriptions._id.edit.popup.changeFrequency.title')
         "
-        :text="$t('account.subscriptions.id.edit.popup.changeFrequency.text')"
+        :text="$t('account.subscriptions._id.edit.popup.changeFrequency.text')"
         :accept-label="
-          $t('account.subscriptions.id.edit.popup.changeFrequency.yes')
+          $t('account.subscriptions._id.edit.popup.changeFrequency.yes')
         "
         :refuse-label="
-          $t('account.subscriptions.id.edit.popup.changeFrequency.no')
+          $t('account.subscriptions._id.edit.popup.changeFrequency.no')
         "
         :loading-label="
-          $t('account.subscriptions.id.edit.popup.changeFrequency.loading')
+          $t('account.subscriptions._id.edit.popup.changeFrequency.loading')
         "
         :plan-id="subscription.planId"
         :options="subscriptionOptions"
@@ -154,15 +154,17 @@
 
       <AccountEditOptionsPopup
         v-if="changeOptionsPopupisActive"
-        :heading="$t('account.subscriptions.id.edit.popup.changeOptions.title')"
+        :heading="
+          $t('account.subscriptions._id.edit.popup.changeOptions.title')
+        "
         :accept-label="
-          $t('account.subscriptions.id.edit.popup.changeOptions.yes')
+          $t('account.subscriptions._id.edit.popup.changeOptions.yes')
         "
         :refuse-label="
-          $t('account.subscriptions.id.edit.popup.changeOptions.no')
+          $t('account.subscriptions._id.edit.popup.changeOptions.no')
         "
         :loading-label="
-          $t('account.subscriptions.id.edit.popup.changeOptions.loading')
+          $t('account.subscriptions._id.edit.popup.changeOptions.loading')
         "
         :options="planOptions"
         :option-state="optionState"
@@ -174,12 +176,12 @@
 
       <AccountConfirmationPopup
         v-if="cancelPopupIsActive"
-        :heading="$t('account.subscriptions.id.popup.cancel.title')"
-        :prompt-message="$t('account.subscriptions.id.popup.cancel.text')"
-        :accept-label="$t('account.subscriptions.id.popup.cancel.yes')"
-        :refuse-label="$t('account.subscriptions.id.popup.cancel.no')"
+        :heading="$t('account.subscriptions._id.popup.cancel.title')"
+        :prompt-message="$t('account.subscriptions._id.popup.cancel.text')"
+        :accept-label="$t('account.subscriptions._id.popup.cancel.yes')"
+        :refuse-label="$t('account.subscriptions._id.popup.cancel.no')"
         :is-loading="isCanceling"
-        :loading-label="$t('account.subscriptions.id.popup.cancel.loading')"
+        :loading-label="$t('account.subscriptions._id.popup.cancel.loading')"
         @accept="cancelSubscription"
         @click-close="cancelPopupIsActive = false"
       />
@@ -332,7 +334,7 @@ export default {
         this.cancelPopupIsActive = false;
 
         this.$store.dispatch('showNotification', {
-          message: this.$t('account.subscriptions.id.popup.cancel.success'),
+          message: this.$t('account.subscriptions._id.popup.cancel.success'),
           type: 'success',
         });
         this.$fetch();
@@ -363,10 +365,10 @@ export default {
           message:
             type === 'frequency'
               ? this.$t(
-                  'account.subscriptions.id.edit.popup.changeFrequency.success',
+                  'account.subscriptions._id.edit.popup.changeFrequency.success',
                 )
               : this.$t(
-                  'account.subscriptions.id.edit.popup.changeOptions.success',
+                  'account.subscriptions._id.edit.popup.changeOptions.success',
                 ),
           type: 'success',
         });

--- a/pages/account/subscriptions/_id/index.vue
+++ b/pages/account/subscriptions/_id/index.vue
@@ -7,7 +7,7 @@
         class="mb-6 flex cursor-pointer items-center"
       >
         <BaseIcon icon="uil:angle-left" size="sm" /><span class="ml-1">
-          {{ $t('account.subscriptions.id.backToSubscriptions') }}
+          {{ $t('account.subscriptions._id.backToSubscriptions') }}
         </span>
       </NuxtLink>
     </div>
@@ -41,7 +41,7 @@
         <!-- Plan items -->
         <template v-if="planItems">
           <span class="label-xs-bold-faded">{{
-            $t('account.subscriptions.id.planItems')
+            $t('account.subscriptions._id.planItems')
           }}</span>
 
           <div class="md:col-gap-4 mb-6 md:grid md:grid-cols-2">
@@ -60,7 +60,7 @@
                 </h4>
                 <p v-if="item.quantity > 1" class="text-sm text-primary-darker">
                   {{
-                    $tc('account.orders.id.quantity', item.quantity, {
+                    $tc('account.orders._id.quantity', item.quantity, {
                       count: item.quantity,
                     })
                   }}
@@ -79,7 +79,7 @@
 
         <template v-else>
           <span class="label-xs-bold-faded">{{
-            $t('account.subscriptions.id.plan')
+            $t('account.subscriptions._id.plan')
           }}</span>
 
           <div class="md:col-gap-4 mb-6 md:grid md:grid-cols-2">
@@ -121,7 +121,7 @@
                   class="text-sm text-primary-darker"
                 >
                   {{
-                    $tc('account.orders.id.quantity', subscription.quantity, {
+                    $tc('account.orders._id.quantity', subscription.quantity, {
                       count: subscription.quantity,
                     })
                   }}
@@ -144,7 +144,7 @@
             :class="{ 'border-b border-primary-med': status !== 'canceled' }"
           >
             <div class="flex pb-2">
-              <span>{{ $t('account.subscriptions.id.planTotal') }}</span>
+              <span>{{ $t('account.subscriptions._id.planTotal') }}</span>
               <span class="ml-auto">
                 {{
                   formatMoneyRounded(
@@ -171,10 +171,10 @@
                 v-if="subscriptionOrder.subscriptionDelivery"
                 class="flex pb-2"
               >
-                <span>{{ $t('account.subscriptions.id.shipping') }}</span>
+                <span>{{ $t('account.subscriptions._id.shipping') }}</span>
                 <span class="ml-auto">{{
                   subscriptionOrder.shipmentPrice === 0
-                    ? $t('account.subscriptions.id.freeShipping')
+                    ? $t('account.subscriptions._id.freeShipping')
                     : formatMoney(
                         subscriptionOrder.shipmentPrice,
                         subscriptionOrder.currency,
@@ -183,7 +183,7 @@
               </div>
 
               <div class="flex text-lg font-semibold">
-                <span>{{ $t('account.subscriptions.id.total') }}</span>
+                <span>{{ $t('account.subscriptions._id.total') }}</span>
                 <span class="ml-auto">{{
                   formatMoneyRounded(
                     subscriptionOrder.grandTotal,
@@ -198,13 +198,13 @@
             <div class="mb-2 flex items-center">
               <BaseIcon icon="uil:calender" size="sm" class="mr-2" />
               <p v-if="status === 'trial'">
-                {{ $t('account.subscriptions.id.trialEnds') }}
+                {{ $t('account.subscriptions._id.trialEnds') }}
                 <span class="label-sm-bold">{{
                   formatDate(subscription.dateTrialEnd)
                 }}</span>
               </p>
               <p v-else-if="status === 'active'">
-                {{ $t('account.subscriptions.id.nextOrder') }}
+                {{ $t('account.subscriptions._id.nextOrder') }}
                 <span class="label-sm-bold">{{
                   formatDate(subscription.datePeriodEnd)
                 }}</span>
@@ -214,7 +214,7 @@
             <div class="flex items-center">
               <BaseIcon icon="uil:sync" size="sm" class="mr-2" />
               <p>
-                {{ $t('account.subscriptions.id.planRenews') }}
+                {{ $t('account.subscriptions._id.planRenews') }}
                 <span class="label-sm-bold">{{ subscription.interval }}</span>
               </p>
             </div>
@@ -224,7 +224,7 @@
               class="mt-6 block w-full"
               fit="auto"
               appearance="dark"
-              :label="$t('account.subscriptions.id.editPlan')"
+              :label="$t('account.subscriptions._id.editPlan')"
               :link="
                 localePath(`/account/subscriptions/${subscription.id}/edit/`)
               "
@@ -237,13 +237,13 @@
         <!-- Delivery details -->
         <template v-if="shipping">
           <p class="pb-4 text-base font-semibold">
-            {{ $t('account.subscriptions.id.deliveryDetails') }}
+            {{ $t('account.subscriptions._id.deliveryDetails') }}
           </p>
 
           <div class="mb-8">
             <div class="rounded border border-primary-med p-4 text-sm">
               <p class="pb-2 font-semibold">
-                {{ $t('account.subscriptions.id.deliveryAddress') }}
+                {{ $t('account.subscriptions._id.deliveryAddress') }}
               </p>
               <p>
                 {{ shipping.name }}<br />
@@ -257,7 +257,7 @@
               class="-mt-px rounded border border-primary-med p-4 text-sm"
             >
               <p class="pb-2 font-semibold">
-                {{ $t('account.subscriptions.id.phoneNumber') }}
+                {{ $t('account.subscriptions._id.phoneNumber') }}
               </p>
               <p>
                 {{ shipping.phone }}
@@ -268,7 +268,7 @@
               class="-mt-px rounded border border-primary-med p-4 text-sm"
             >
               <p class="pb-2 font-semibold">
-                {{ $t('account.subscriptions.id.deliveryMethod') }}
+                {{ $t('account.subscriptions._id.deliveryMethod') }}
               </p>
               <p v-if="shipping.serviceName">
                 {{ shipping.serviceName }}
@@ -286,7 +286,7 @@
             class="mb-8"
             appearance="light"
             fit="auto"
-            :label="$t('account.subscriptions.id.changeDelivery')"
+            :label="$t('account.subscriptions._id.changeDelivery')"
             @click.native="editShippingAddressPopupIsActive = true"
           />
         </template>
@@ -294,7 +294,7 @@
         <!-- Payment details -->
         <div class="mb-8">
           <p class="pb-4 text-base font-semibold">
-            {{ $t('account.subscriptions.id.paymentMethod') }}
+            {{ $t('account.subscriptions._id.paymentMethod') }}
           </p>
 
           <div
@@ -336,7 +336,7 @@
             <div v-if="billing" class="flex p-4 md:text-sm">
               <div>
                 <p class="pb-2 font-semibold">
-                  {{ $t('account.subscriptions.id.billingAddress') }}
+                  {{ $t('account.subscriptions._id.billingAddress') }}
                 </p>
                 <p>
                   {{ billing.name }}<br />
@@ -352,7 +352,7 @@
                 class="mt-auto ml-auto px-2"
                 @click="editBillingAddressPopupIsActive = true"
               >
-                {{ $t('account.subscriptions.id.editBillingAddress') }}
+                {{ $t('account.subscriptions._id.editBillingAddress') }}
               </button>
             </div>
           </div>
@@ -368,18 +368,18 @@
           <p class="pb-4 text-base font-semibold">
             {{
               status === 'paused'
-                ? $t('account.subscriptions.id.resume.title')
-                : $t('account.subscriptions.id.pause.title')
+                ? $t('account.subscriptions._id.resume.title')
+                : $t('account.subscriptions._id.pause.title')
             }}
           </p>
 
           <p class="pb-10">
             {{
               status === 'paused'
-                ? $t('account.subscriptions.id.resume.message', {
+                ? $t('account.subscriptions._id.resume.message', {
                     date: formatDate(subscription.datePaused),
                   })
-                : $t('account.subscriptions.id.pause.message')
+                : $t('account.subscriptions._id.pause.message')
             }}
           </p>
 
@@ -388,8 +388,8 @@
             fit="auto"
             :label="
               status === 'paused'
-                ? $t('account.subscriptions.id.resume.label')
-                : $t('account.subscriptions.id.pause.label')
+                ? $t('account.subscriptions._id.resume.label')
+                : $t('account.subscriptions._id.pause.label')
             "
             @click.native="pauseResumeSubscriptionPopupIsActive = true"
           />
@@ -400,7 +400,7 @@
         <!-- Orders -->
         <div v-if="orders" class="mb-10">
           <p class="pt-10 pb-4 text-base font-semibold">
-            {{ $t('account.subscriptions.id.orders') }}
+            {{ $t('account.subscriptions._id.orders') }}
           </p>
 
           <NuxtLink
@@ -422,7 +422,7 @@
           class="block md:inline-block"
           appearance="light-error"
           fit="auto"
-          :label="$t('account.subscriptions.id.cancelSubscription')"
+          :label="$t('account.subscriptions._id.cancelSubscription')"
           @click.native="cancelPopupIsActive = true"
         />
       </div>
@@ -470,12 +470,12 @@
 
     <AccountConfirmationPopup
       v-if="cancelPopupIsActive"
-      :heading="$t('account.subscriptions.id.popup.cancel.title')"
-      :prompt-message="$t('account.subscriptions.id.popup.cancel.text')"
-      :accept-label="$t('account.subscriptions.id.popup.cancel.yes')"
-      :refuse-label="$t('account.subscriptions.id.popup.cancel.no')"
+      :heading="$t('account.subscriptions._id.popup.cancel.title')"
+      :prompt-message="$t('account.subscriptions._id.popup.cancel.text')"
+      :accept-label="$t('account.subscriptions._id.popup.cancel.yes')"
+      :refuse-label="$t('account.subscriptions._id.popup.cancel.no')"
       :is-loading="isUpdating"
-      :loading-label="$t('account.subscriptions.id.popup.cancel.loading')"
+      :loading-label="$t('account.subscriptions._id.popup.cancel.loading')"
       @accept="cancelSubscription"
       @click-close="cancelPopupIsActive = false"
     />
@@ -702,7 +702,7 @@ export default {
 
           this.$store.dispatch('showNotification', {
             message: this.$t(
-              'account.subscriptions.id.popup.pause.skipCycleSuccess',
+              'account.subscriptions._id.popup.pause.skipCycleSuccess',
             ),
             type: 'success',
           });
@@ -714,7 +714,7 @@ export default {
           });
 
           this.$store.dispatch('showNotification', {
-            message: this.$t('account.subscriptions.id.popup.pause.success'),
+            message: this.$t('account.subscriptions._id.popup.pause.success'),
             type: 'success',
           });
         }
@@ -751,10 +751,10 @@ export default {
         this.selectDateTimePopupIsActive = false;
         this.$store.dispatch('showNotification', {
           message: date
-            ? this.$t('account.subscriptions.id.popup.chooseDate.success', {
+            ? this.$t('account.subscriptions._id.popup.chooseDate.success', {
                 date: this.formatDate(date),
               })
-            : this.$t('account.subscriptions.id.popup.resume.success'),
+            : this.$t('account.subscriptions._id.popup.resume.success'),
           type: 'success',
         });
         this.$fetch();
@@ -776,7 +776,7 @@ export default {
         this.cancelPopupIsActive = false;
 
         this.$store.dispatch('showNotification', {
-          message: this.$t('account.subscriptions.id.popup.cancel.success'),
+          message: this.$t('account.subscriptions._id.popup.cancel.success'),
           type: 'success',
         });
         this.$fetch();


### PR DESCRIPTION
Slugs are being shown in the customer portal of 'Orders and Returns' and 'Subscriptions' pages.

<details>
<summary>Bug reference</summary>

![image](https://github.com/swellstores/origin-theme/assets/100766131/a65db71a-2a91-4304-8507-278ac266add5)
![image (7)](https://github.com/swellstores/origin-theme/assets/100766131/b7b09035-cce4-4ce1-b470-660d31c644cf)

</details>

<details>
<summary>Screenshots after bug fix</summary>

<img width="1512" alt="Screenshot 2023-06-23 at 1 50 48 PM" src="https://github.com/swellstores/origin-theme/assets/100766131/fc13ec96-16e5-47f3-bc03-902a5200bab1">
<img width="1502" alt="Screenshot 2023-06-23 at 1 51 17 PM" src="https://github.com/swellstores/origin-theme/assets/100766131/55526538-5802-400a-8055-0036cfab4199">
</details>

### Other information:
<details>

<summary>Added `generate` step inside build command to resolve build error.</summary>

<img width="1201" alt="Screenshot 2023-07-04 at 10 34 07 AM" src="https://github.com/swellstores/origin-theme/assets/100766131/8631cfa7-c2d7-420e-b723-701325c68d7d">
</details>

<details>

<summary>Many developers miss to add `nuxt generate` step while deploying in Vercel.</summary>

So, I included it as part of the build instructions so that there's no change required in Vercel Build settings as shown below:

<img width="927" alt="Screenshot 2023-07-04 at 10 35 18 AM" src="https://github.com/swellstores/origin-theme/assets/100766131/57241428-44ad-4541-95c5-8f0b4ef2f99b">
</details>

<details>
<summary>Setting fixed node version in engine settings to avoid Vercel picking up the latest supported version (v18.16.1)</summary>

<img width="1207" alt="Screenshot 2023-07-04 at 10 42 33 AM" src="https://github.com/swellstores/origin-theme/assets/100766131/51c78238-b9d3-41ff-87fa-edf02477c334">

</details>