### PR TITLE
Fix: Page Title on Customer's Subscription page is not shown correctly

### DIFF
--- a/pages/account/subscriptions/_id/edit.vue
+++ b/pages/account/subscriptions/_id/edit.vue
@@ -244,6 +244,12 @@ export default {
     this.resetOptionValues();
   },
 
+  head() {
+    if (!this.subscription)
+      return { title: this.$t('account.subscriptions.title') };
+    return { title: this.subscription.product.name };
+  },
+
   computed: {
     ...mapState(['currency']),
 

--- a/pages/account/subscriptions/_id/index.vue
+++ b/pages/account/subscriptions/_id/index.vue
@@ -570,6 +570,12 @@ export default {
     }
   },
 
+  head() {
+    if (!this.subscription)
+      return { title: this.$t('account.subscriptions.title') };
+    return { title: this.subscription.product.name };
+  },
+
   computed: {
     ...mapState(['currency']),
 


### PR DESCRIPTION
Issue ( https://app.asana.com/0/1202306318068147/1203236915188784/f )

Missing head() code on subscription pages

```  
head() {
    if (!this.subscription)
      return { title: this.$t('account.subscriptions.title') };
    return { title: this.subscription.product.name };
  },
```

https://github.com/swellstores/origin-theme/assets/145032708/90b01b97-e54c-476b-a4b1-cf81bb766cb6


